### PR TITLE
Changing the Apt key for jenkins on Ubuntu

### DIFF
--- a/ubuntu/21.04/430-systemd/playbooks/virtualbox.yml
+++ b/ubuntu/21.04/430-systemd/playbooks/virtualbox.yml
@@ -44,7 +44,7 @@
         proto: tcp
     - name: add Jenkins apt key
       ansible.builtin.apt_key:
-        url: https://pkg.jenkins.io/debian-stable/jenkins.io.key
+        url: https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
         state: present
     - name: Jenkins deb repository
       ansible.builtin.apt_repository:

--- a/ubuntu/22.04/010-basic/playbooks/virtualbox.yml
+++ b/ubuntu/22.04/010-basic/playbooks/virtualbox.yml
@@ -50,7 +50,7 @@
         proto: tcp
     - name: add Jenkins apt key
       ansible.builtin.apt_key:
-        url: https://pkg.jenkins.io/debian-stable/jenkins.io.key
+        url: https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
         state: present
     - name: Jenkins deb repository
       ansible.builtin.apt_repository:


### PR DESCRIPTION
According to the following link from jenkins.io, from March 28, 2023, the URL for the Jenkins apt key changed, resulting in an error when adding the key using Ansible.
https://www.jenkins.io/blog/2023/03/27/repository-signing-keys-changing/


Error:
```
TASK [add Jenkins apt key] ************************************************************************************************************************************************************************************************
fatal: [jenkins]: FAILED! => {"after": ["8D81803C0EBFCD88", "7EA0A9C3F273FCD8", "843C48A565F8F04B", "3F4A517504A9CD61", "8D81803C0EBFCD88", "7EA0A9C3F273FCD8", "D94AA3F0EFE21092", "871920D1991BC93C"], "before": ["8D81803C0EBFCD88", "7EA0A9C3F273FCD8", "843C48A565F8F04B", "3F4A517504A9CD61", "8D81803C0EBFCD88", "7EA0A9C3F273FCD8", "D94AA3F0EFE21092", "871920D1991BC93C"], "changed": true, "fp": "FCEF32E745F2C3D5", "id": "FCEF32E745F2C3D5", "key_id": "FCEF32E745F2C3D5", "msg": "apt-key did not return an error, but failed to add the key (check that the id is correct and *not* a subkey)", "short_id": "45F2C3D5"}
```